### PR TITLE
fix: Update manticore.conf

### DIFF
--- a/sources/manticore-worker/manticore.conf
+++ b/sources/manticore-worker/manticore.conf
@@ -1,4 +1,4 @@
 #!/bin/sh
 sed 's/$hostname/'$(hostname -f)'/' $CONFIGMAP_PATH | \
-sed 's/\.svc\.cluster\.local//' | \
+sed 's/\.svc\.[.a-zA-Z0-9-]\+//' | \
 sed 's/$server_id/'$(echo $HOSTNAME | sed 's/.*-//')'/'


### PR DESCRIPTION
This fixes a shortcoming in the manticore.conf wrapper for updating local configuration: it doesn't take possible deviations from standard kubernetes cluster DNS into consideration.

Kubernetes doesn't enforce svc.cluster.local and in fact you can have different DNS in place there. For anything that differs from svc.cluster.local, this script fails and thus blocks clustering.